### PR TITLE
Correct Drain function name typo

### DIFF
--- a/ico.sol
+++ b/ico.sol
@@ -265,7 +265,7 @@ contract Crowdsale is Pausable {
     }
 
     // @notice Fail-safe token transfer
-    function tokenDrian() external onlyOwner() {
+    function tokenDrain() external onlyOwner() {
         if (block.number > endBlock) {
             if (!token.transfer(team, token.balanceOf(this))) 
                 revert();


### PR DESCRIPTION
Correcting a typo in a function name: tokenDrain. I don't see that function is called, but misspelling should not persist.